### PR TITLE
Add `dir` output support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -152,7 +152,7 @@ export default function gltf(opts = {}) {
     },
 
     generateBundle(options) {
-      const outputDir = path.dirname(options.file);
+      const outputDir = path.dirname(options.file || options.dir);
       const files = Object.keys(additionalFiles);
 
       const copies = files.map(


### PR DESCRIPTION
Fixes 
````
[!] (plugin gltf) TypeError: The "path" argument must be of type string. Received undefined
````
when specifying output via `dir`